### PR TITLE
custom $argv + get result from main() instead exiting application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 apigen.phar
 docs/
 
+/nbproject/private/

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "lottestyle/php-cli",
+  "name": "splitbrain/php-cli",
   "description": "Easy command line scripts for PHP with opt parsing and color output. No dependencies",
   "keywords": [
     "cli",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "splitbrain/php-cli",
+  "name": "lottestyle/php-cli",
   "description": "Easy command line scripts for PHP with opt parsing and color output. No dependencies",
   "keywords": [
     "cli",

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -38,17 +38,18 @@ abstract class CLI
      * constructor
      *
      * Initialize the arguments, set up helper classes and set up the CLI environment
-     *
+     *     
      * @param bool $autocatch should exceptions be catched and handled automatically?
+     * @param 
      */
-    public function __construct($autocatch = true)
+    public function __construct($autocatch = true, $args = null)
     {
         if ($autocatch) {
             set_exception_handler(array($this, 'fatal'));
         }
 
         $this->colors = new Colors();
-        $this->options = new Options($this->colors);
+        $this->options = new Options($this->colors, $args);
     }
 
     /**
@@ -68,12 +69,16 @@ abstract class CLI
      * @return void
      */
     abstract protected function main(Options $options);
-
+    
     /**
      * Execute the CLI program
      *
      * Executes the setup() routine, adds default options, initiate the options parsing and argument checking
      * and finally executes main()
+     * 
+     * Returns result from main() 
+     * 
+     * @return mixed
      */
     public function run()
     {
@@ -122,9 +127,7 @@ abstract class CLI
         $this->options->checkArguments();
 
         // execute
-        $this->main($this->options);
-
-        exit(0);
+        return $this->main($this->options);
     }
 
     // region logging

--- a/src/Options.php
+++ b/src/Options.php
@@ -35,9 +35,10 @@ class Options
      * Constructor
      *
      * @param Colors $colors optional configured color object
+     * @param array $args custom arguments
      * @throws Exception when arguments can't be read
      */
-    public function __construct(Colors $colors = null)
+    public function __construct(Colors $colors = null, $args = null)
     {
         if (!is_null($colors)) {
             $this->colors = $colors;
@@ -52,8 +53,12 @@ class Options
                 'help' => ''
             )
         ); // default command
-
-        $this->args = $this->readPHPArgv();
+        
+        if ($args === null) {
+          $this->args = $this->readPHPArgv();
+        }else{
+          $this->args = $args;
+        }
         $this->bin = basename(array_shift($this->args));
 
         $this->options = array();
@@ -463,6 +468,15 @@ class Options
             return $_SERVER['argv'];
         }
         return $argv;
+    }
+    
+    /**
+     * Sets
+     * 
+     * @param array $args
+     */
+    public function setArgs(array $args) {
+      
     }
 }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -470,13 +470,5 @@ class Options
         return $argv;
     }
     
-    /**
-     * Sets
-     * 
-     * @param array $args
-     */
-    public function setArgs(array $args) {
-      
-    }
 }
 


### PR DESCRIPTION
Developer should be able to set up $args property in Options class manually. This is useful for example in unit testing.

->run() method should return result of ->main() - again this is useful in unit testing.