### PR TITLE
Added missing @throws tags to PHPDoc.

### DIFF
--- a/src/CLI.php
+++ b/src/CLI.php
@@ -56,6 +56,8 @@ abstract class CLI
      *
      * @param Options $options
      * @return void
+     *
+     * @throws Exception
      */
     abstract protected function setup(Options $options);
 
@@ -66,6 +68,8 @@ abstract class CLI
      *
      * @param Options $options
      * @return void
+     *
+     * @throws Exception
      */
     abstract protected function main(Options $options);
 
@@ -74,6 +78,8 @@ abstract class CLI
      *
      * Executes the setup() routine, adds default options, initiate the options parsing and argument checking
      * and finally executes main()
+     *
+     * @throws Exception
      */
     public function run()
     {

--- a/src/Colors.php
+++ b/src/Colors.php
@@ -99,9 +99,11 @@ class Colors
     /**
      * Convenience function to print a line in a given color
      *
-     * @param string $line the line to print, a new line is added automatically
-     * @param string $color one of the available color names
+     * @param string   $line    the line to print, a new line is added automatically
+     * @param string   $color   one of the available color names
      * @param resource $channel file descriptor to write to
+     *
+     * @throws Exception
      */
     public function ptln($line, $color, $channel = STDOUT)
     {
@@ -158,6 +160,8 @@ class Colors
      * reset the terminal color
      *
      * @param resource $channel file descriptor to write to
+     *
+     * @throws Exception
      */
     public function reset($channel = STDOUT)
     {

--- a/src/Options.php
+++ b/src/Options.php
@@ -285,7 +285,7 @@ class Options
      *
      * @param mixed $option
      * @param bool|string $default what to return if the option was not set
-     * @return bool|string
+     * @return bool|string|string[]
      */
     public function getOpt($option = null, $default = false)
     {
@@ -325,6 +325,8 @@ class Options
      * Builds a help screen from the available options. You may want to call it from -h or on error
      *
      * @return string
+     *
+     * @throws Exception
      */
     public function help()
     {


### PR DESCRIPTION
Since PHPStorm added the "unhandled exception" and "missing throws tag" inspections in today's update I noticed that those were missing in a few places here.