### PR TITLE
mb_substr() treats $length differently than substr()

### DIFF
--- a/src/TableFormatter.php
+++ b/src/TableFormatter.php
@@ -273,7 +273,12 @@ class TableFormatter
         if (function_exists('mb_substr')) {
             return mb_substr($string, $start, $length);
         } else {
-            return substr($string, $start, $length);
+            // mb_substr() treats $length differently than substr()
+            if ($length) {
+                return substr($string, $start, $length);
+            } else {
+                return substr($string, $start);
+            }
         }
     }
 


### PR DESCRIPTION
Got this from a psalm warning and checked what [php.net/substr](http://php.net/substr) vs [php.net/mb_substr](http://php.net/mb_substr) said.