### PR TITLE
Use other libraries to improve robustness and trim code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": ">=5.3.0",
     "jakub-onderka/php-console-color": "0.1",
-    "hexmode/io-mode": "1.0"
+    "hexmode/io-mode": "0.9"
   },
   "suggest": {
     "psr/log": "Allows you to make the CLI available as PSR-3 logger"

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,16 @@
     {
       "name": "Andreas Gohr",
       "email": "andi@splitbrain.org"
+    },
+    {
+      "name": "Mark A. Hershberger",
+      "email": "mah@nichework.com"
     }
   ],
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=5.3.0",
+    "jakub-onderka/php-console-color": "0.1",
+    "hexmode/io-mode": "1.0"
   },
   "suggest": {
     "psr/log": "Allows you to make the CLI available as PSR-3 logger"

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -25,13 +25,14 @@ abstract class CLI
         'info' => array('ℹ ', Colors::C_CYAN, STDOUT),
         'notice' => array('☛ ', Colors::C_CYAN, STDOUT),
         'success' => array('✓ ', Colors::C_GREEN, STDOUT),
-        'warning' => array('⚠ ', Colors::C_BROWN, STDERR),
+        'warning' => array('⚠ ', Colors::C_YELLOW, STDERR),
         'error' => array('✗ ', Colors::C_RED, STDERR),
         'critical' => array('☠ ', Colors::C_LIGHTRED, STDERR),
         'alert' => array('✖ ', Colors::C_LIGHTRED, STDERR),
         'emergency' => array('✘ ', Colors::C_LIGHTRED, STDERR),
     );
 
+    /** @var string log level */
     protected $logdefault = 'info';
 
     /**

--- a/src/Colors.php
+++ b/src/Colors.php
@@ -2,6 +2,9 @@
 
 namespace splitbrain\phpcli;
 
+use JakubOnderka\PhpConsoleColor\ConsoleColor;
+use Hexmode\IOMode\IOMode;
+
 /**
  * Class Colors
  *
@@ -15,45 +18,29 @@ class Colors
     // these constants make IDE autocompletion easier, but color names can also be passed as strings
     const C_RESET = 'reset';
     const C_BLACK = 'black';
-    const C_DARKGRAY = 'darkgray';
+    const C_DARKGRAY = 'dark_gray';
     const C_BLUE = 'blue';
-    const C_LIGHTBLUE = 'lightblue';
+    const C_LIGHTBLUE = 'light_blue';
     const C_GREEN = 'green';
-    const C_LIGHTGREEN = 'lightgreen';
+    const C_LIGHTGREEN = 'light_green';
     const C_CYAN = 'cyan';
-    const C_LIGHTCYAN = 'lightcyan';
+    const C_LIGHTCYAN = 'light_cyan';
     const C_RED = 'red';
-    const C_LIGHTRED = 'lightred';
-    const C_PURPLE = 'purple';
-    const C_LIGHTPURPLE = 'lightpurple';
-    const C_BROWN = 'brown';
+    const C_LIGHTRED = 'light_red';
+    const C_MAGENTA = 'magenta';
+    const C_LIGHTMAGENTA = 'light_magenta';
+    const C_PURPLE = 'magenta';
+    const C_LIGHTPURPLE = 'light_magenta';
     const C_YELLOW = 'yellow';
-    const C_LIGHTGRAY = 'lightgray';
+    const C_LIGHTYELLOW = 'light_yellow';
+    const C_LIGHTGRAY = 'light_gray';
     const C_WHITE = 'white';
-
-    /** @var array known color names */
-    protected $colors = array(
-        self::C_RESET => "\33[0m",
-        self::C_BLACK => "\33[0;30m",
-        self::C_DARKGRAY => "\33[1;30m",
-        self::C_BLUE => "\33[0;34m",
-        self::C_LIGHTBLUE => "\33[1;34m",
-        self::C_GREEN => "\33[0;32m",
-        self::C_LIGHTGREEN => "\33[1;32m",
-        self::C_CYAN => "\33[0;36m",
-        self::C_LIGHTCYAN => "\33[1;36m",
-        self::C_RED => "\33[0;31m",
-        self::C_LIGHTRED => "\33[1;31m",
-        self::C_PURPLE => "\33[0;35m",
-        self::C_LIGHTPURPLE => "\33[1;35m",
-        self::C_BROWN => "\33[0;33m",
-        self::C_YELLOW => "\33[1;33m",
-        self::C_LIGHTGRAY => "\33[0;37m",
-        self::C_WHITE => "\33[1;37m",
-    );
 
     /** @var bool should colors be used? */
     protected $enabled = true;
+
+    /** @var ConsoleColor $console */
+    protected $console;
 
     /**
      * Constructor
@@ -62,11 +49,13 @@ class Colors
      */
     public function __construct()
     {
-        if (function_exists('posix_isatty') && !posix_isatty(STDOUT)) {
+        $this->console = new ConsoleColor();
+        $ioMode = new IOMode( STDOUT );
+        if ( $ioMode->tty() === false || $ioMode->fifo() ) {
             $this->enabled = false;
             return;
         }
-        if (!getenv('TERM')) {
+        if ( $this->console->isSupported() ) {
             $this->enabled = false;
             return;
         }
@@ -107,64 +96,21 @@ class Colors
      */
     public function ptln($line, $color, $channel = STDOUT)
     {
-        $this->set($color);
-        fwrite($channel, rtrim($line) . "\n");
-        $this->reset();
+        fwrite(
+            $channel, $this->console->apply( $color, rtrim( $line ) . "\n" )
+        );
     }
 
     /**
-     * Returns the given text wrapped in the appropriate color and reset code
+     * Returns the given text wrapped in the appropriate color and
+     * reset code
      *
      * @param string $text string to wrap
      * @param string $color one of the available color names
      * @return string the wrapped string
      * @throws Exception
      */
-    public function wrap($text, $color)
-    {
-        return $this->getColorCode($color) . $text . $this->getColorCode('reset');
-    }
-
-    /**
-     * Gets the appropriate terminal code for the given color
-     *
-     * @param string $color one of the available color names
-     * @return string color code
-     * @throws Exception
-     */
-    public function getColorCode($color)
-    {
-        if (!$this->enabled) {
-            return '';
-        }
-        if (!isset($this->colors[$color])) {
-            throw new Exception("No such color $color");
-        }
-
-        return $this->colors[$color];
-    }
-
-    /**
-     * Set the given color for consecutive output
-     *
-     * @param string $color one of the supported color names
-     * @param resource $channel file descriptor to write to
-     * @throws Exception
-     */
-    public function set($color, $channel = STDOUT)
-    {
-        fwrite($channel, $this->getColorCode($color));
-    }
-
-    /**
-     * reset the terminal color
-     *
-     * @param resource $channel file descriptor to write to
-     *
-     * @throws Exception
-     */
-    public function reset($channel = STDOUT)
-    {
-        $this->set('reset', $channel);
+    public function wrap( $text, $color ) {
+        return $this->console->apply( $color, $text );
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -340,7 +340,7 @@ class Options
 
             // usage or command syntax line
             if (!$command) {
-                $text .= $this->colors->wrap('USAGE:', Colors::C_BROWN);
+                $text .= $this->colors->wrap('USAGE:', Colors::C_YELLOW);
                 $text .= "\n";
                 $text .= '   ' . $this->bin;
                 $mv = 2;
@@ -381,7 +381,7 @@ class Options
             if ($hasopts) {
                 if (!$command) {
                     $text .= "\n";
-                    $text .= $this->colors->wrap('OPTIONS:', Colors::C_BROWN);
+                    $text .= $this->colors->wrap('OPTIONS:', Colors::C_YELLOW);
                 }
                 $text .= "\n";
                 foreach ($this->setup[$command]['opts'] as $long => $opt) {
@@ -412,7 +412,7 @@ class Options
             if ($hasargs) {
                 if (!$command) {
                     $text .= "\n";
-                    $text .= $this->colors->wrap('ARGUMENTS:', Colors::C_BROWN);
+                    $text .= $this->colors->wrap('ARGUMENTS:', Colors::C_YELLOW);
                 }
                 $text .= "\n";
                 foreach ($this->setup[$command]['args'] as $arg) {
@@ -429,7 +429,7 @@ class Options
             // head line and intro for following command documentation
             if (!$command && $hascommands) {
                 $text .= "\n";
-                $text .= $this->colors->wrap('COMMANDS:', Colors::C_BROWN);
+                $text .= $this->colors->wrap('COMMANDS:', Colors::C_YELLOW);
                 $text .= "\n";
                 $text .= $tf->format(
                     array($mv, '*'),

--- a/tests/TableFormatterTest.php
+++ b/tests/TableFormatterTest.php
@@ -99,6 +99,9 @@ class TableFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function test_length()
     {
+        if(!extension_loaded('mbstring')) {
+            $this->markTestSkipped('No multi-byte handling in this PHP.');
+        }
         $text = "this is häppy ☺";
         $expect = "$text     |test";
 

--- a/tests/TableFormatterTest.php
+++ b/tests/TableFormatterTest.php
@@ -104,7 +104,7 @@ class TableFormatterTest extends \PHPUnit_Framework_TestCase
 
         $tf = new TableFormatter();
         $tf->setBorder('|');
-        $result = $tf->format([20, '*'], [$text, 'test']);
+        $result = $tf->format(array(20, '*'), array($text, 'test'));
 
         $this->assertEquals($expect, trim($result));
     }
@@ -118,7 +118,7 @@ class TableFormatterTest extends \PHPUnit_Framework_TestCase
 
         $tf = new TableFormatter();
         $tf->setBorder('|');
-        $result = $tf->format([20, '*'], [$text, 'test']);
+        $result = $tf->format(array(20, '*'), array($text, 'test'));
 
         $this->assertEquals($expect, trim($result));
     }
@@ -135,7 +135,7 @@ class TableFormatterTest extends \PHPUnit_Framework_TestCase
         $tf->setMaxWidth(11);
         $tf->setBorder('|');
 
-        $result = $tf->format([5, '*'], [$col1, $col2]);
+        $result = $tf->format(array(5, '*'), array($col1, $col2));
         $this->assertEquals($expect, $result);
     }
 }


### PR DESCRIPTION
* hexmode/io-info for “Is this a TTY or a file?”
* jakub-onderka/php-console-color for color codes.
  * Use ANSI color names[1] as it does plus some attempt at back-compat

[1]  https://en.wikipedia.org/wiki/ANSI_escape_code#Colors