### PR TITLE
Reset the color instead of setting it to light gray for debugging

### DIFF
--- a/src/CLI.php
+++ b/src/CLI.php
@@ -21,7 +21,7 @@ abstract class CLI
 
     /** @var array PSR-3 compatible loglevels and their prefix, color, output channel */
     protected $loglevel = array(
-        'debug' => array('', Colors::C_LIGHTGRAY, STDOUT),
+        'debug' => array('', Colors::C_RESET, STDOUT),
         'info' => array('ℹ ', Colors::C_CYAN, STDOUT),
         'notice' => array('☛ ', Colors::C_CYAN, STDOUT),
         'success' => array('✓ ', Colors::C_GREEN, STDOUT),


### PR DESCRIPTION
Otherwise, the debugging information is impossible to read on a light
colored background.  At least, for my 46 year old eyes.