### PR TITLE
Add an accessor function to options for bin

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -58,6 +58,14 @@ class Options
 
         $this->options = array();
     }
+    
+    /**
+     * Gets the bin value
+     */
+    public function getBin()
+    {
+        return $this->bin;
+    }
 
     /**
      * Sets the help text for the tool itself


### PR DESCRIPTION
The base CLI.php class has a property for bin but it is not populated.  This change makes the property on the options class available to classes that extend CLI.