### PR TITLE
more tests, upgraded phpunit, ability to pass array of commands to registerOption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: php
 sudo: false
 dist: trusty
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It is lightweight and has **no 3rd party dependencies**. Note: this is for non-i
 
 Use composer:
 
-```php composer.phar require splitbrain/php-cli```
+```composer require splitbrain/php-cli```
 
 ## Usage and Examples
 
@@ -82,7 +82,7 @@ exit the program with a non-zero exit code. You can disable this behaviour and c
 passing false to the constructor.
 
 You can use the provided ``splitbrain\phpcli\Exception`` to signal any problems within your main code yourself. The
-exception's code will be used as the exit code then.
+exceptions' code will be used as the exit code then.
 
 Stacktraces will be printed on log level `debug`. 
 
@@ -93,7 +93,7 @@ then uses terminal colors. You can always suppress colored output by passing ``-
 Disabling colors will also disable the emoticon prefixes.
 
 Simple colored log messages can be printed by you using the convinence methods ``success()`` (green), ``info()`` (cyan),
-``error()`` (red) or ``fatal()`` (red). The latter will also exit the programm with a non-zero exit code.
+``error()`` (red) or ``fatal()`` (red). The latter will also exit the program with a non-zero exit code.
 
 For more complex coloring you can access the color class through ``$this->colors`` in your script. The ``wrap()`` method
 is probably what you want to use.
@@ -156,3 +156,99 @@ Messages from `warning` level onwards are printed to `STDERR` all below are prin
 The default log level of your script can be set by overwriting the `$logdefault` member.
 
 See `example/logging.php` for an example.
+
+##Command Example
+```php
+#!/usr/bin/php
+<?php
+namespace myapp;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use splitbrain\phpcli\CLI;
+use splitbrain\phpcli\Options;
+
+// an example of creating a registry of commands
+// place in a separate file in the same namespace
+class cliCmds
+{
+    const create = 'create';
+    const delete = 'delete';
+}
+
+// an example of creating a registry of options
+// place in a separate file in the same namespace
+class cliOpts
+{
+    const name = 'name';
+    const nameShort = 'n';
+    const nameArg = 'name';
+}
+
+class app extends CLI
+{
+    // register options and arguments
+    protected function setup( Options $options )
+    {
+        $options->registerCommand( cliCmds::create, 'Create a new entry' );
+        $options->registerCommand( cliCmds::delete, 'Delete an entry' );
+
+        // showing registering an option for two commands
+        $options->registerOption(
+            cliOpts::name,
+            'The entry name',
+            cliOpts::nameShort,
+            cliOpts::nameArg,
+            [cliCmds::create, cliCmds::delete]
+        );
+
+        $options->setHelp( 'An example showing commands' );
+    }
+
+
+    protected function main( Options $options )
+    {
+        // show the name of the program and its version
+        $this->info( $this->options->getBin() . ' v1.0.0' );
+
+        switch ( $options->getCmd() ) {
+            case cliCmds::create:
+                $this->create( $name );
+                break;
+
+            case cliCmds::delete:
+                $this->delete( $name );
+                break;
+
+            default:
+                echo $options->help();
+        }
+    }
+
+
+    protected function delete( $name )
+    {
+        if( ! $name = $this->options->getOpt( cliOpts::name ) )
+        {
+            echo $this->options->help();
+            $this->fatal( 'Missing  --' . cliOpts::name );
+        }
+        $this->success( 'Deleted an entry for ' . $name );
+    }
+
+
+    protected function create( $name )
+    {
+        if( ! $name = $this->options->getOpt( cliOpts::name ) )
+        {
+            echo $this->options->help();
+            $this->fatal( 'Missing  --' . cliOpts::name );
+        }
+        $this->success( 'Created an entry for ' . $name );
+    }
+}
+
+// execute it
+$cli = new app();
+$cli->run();
+```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The default log level of your script can be set by overwriting the `$logdefault`
 
 See `example/logging.php` for an example.
 
-##Command Example
+## Command Example
 ```php
 #!/usr/bin/php
 <?php

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ for further info.
 ## Exceptions
 
 By default the CLI class registers an exception handler and will print the exception's message to the end user and
-exit the programm with a non-zero exit code. You can disable this behaviour and catch all exceptions yourself by
+exit the program with a non-zero exit code. You can disable this behaviour and catch all exceptions yourself by
 passing false to the constructor.
 
 You can use the provided ``splitbrain\phpcli\Exception`` to signal any problems within your main code yourself. The
-exceptions's code will be used as the exit code then.
+exception's code will be used as the exit code then.
 
 Stacktraces will be printed on log level `debug`. 
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "psr/log": "Allows you to make the CLI available as PSR-3 logger"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.5.*"
+    "phpunit/phpunit": "^6"
   },
   "autoload": {
     "psr-4": {

--- a/examples/commands.php
+++ b/examples/commands.php
@@ -1,0 +1,92 @@
+#!/usr/bin/php
+<?php
+namespace myapp;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use splitbrain\phpcli\CLI;
+use splitbrain\phpcli\Options;
+
+// an example of creating a registry of commands
+// place in a separate file in the same namespace
+class cliCmds
+{
+    const create = 'create';
+    const delete = 'delete';
+}
+
+// an example of creating a registry of options
+// place in a separate file in the same namespace
+class cliOpts
+{
+    const name = 'name';
+    const nameShort = 'n';
+    const nameArg = 'name';
+}
+
+class app extends CLI
+{
+    // register options and arguments
+    protected function setup( Options $options )
+    {
+        $options->registerCommand( cliCmds::create, 'Create a new entry' );
+        $options->registerCommand( cliCmds::delete, 'Delete an entry' );
+
+        // showing registering an option for two commands
+        $options->registerOption(
+            cliOpts::name,
+            'The entry name',
+            cliOpts::nameShort,
+            cliOpts::nameArg,
+            [cliCmds::create, cliCmds::delete]
+        );
+
+        $options->setHelp( 'An example showing commands' );
+    }
+
+
+    protected function main( Options $options )
+    {
+        // show the name of the program and its version
+        $this->info( $this->options->getBin() . ' v1.0.0' );
+
+        switch ( $options->getCmd() ) {
+            case cliCmds::create:
+                $this->create( $name );
+                break;
+
+            case cliCmds::delete:
+                $this->delete( $name );
+                break;
+
+            default:
+                echo $options->help();
+        }
+    }
+
+
+    protected function delete( $name )
+    {
+        if( ! $name = $this->options->getOpt( cliOpts::name ) )
+        {
+            echo $this->options->help();
+            $this->fatal( 'Missing  --' . cliOpts::name );
+        }
+        $this->success( 'Deleted an entry for ' . $name );
+    }
+
+
+    protected function create( $name )
+    {
+        if( ! $name = $this->options->getOpt( cliOpts::name ) )
+        {
+            echo $this->options->help();
+            $this->fatal( 'Missing  --' . cliOpts::name );
+        }
+        $this->success( 'Created an entry for ' . $name );
+    }
+}
+
+// execute it
+$cli = new app();
+$cli->run();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
          syntaxCheck="false">
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/TableFormatter.php
+++ b/src/TableFormatter.php
@@ -95,12 +95,11 @@ class TableFormatter
         if (isset($_SERVER['COLUMNS'])) return (int)$_SERVER['COLUMNS'];
 
         // via tput
-        $process = proc_open('tput cols', array(
-            1 => array('pipe', 'w'),
-            2 => array('pipe', 'w'),
-        ), $pipes);
-        $width = (int)stream_get_contents($pipes[1]);
-        proc_close($process);
+        $width = shell_exec( 'tput cols' );
+        if( $width != (int)$width )
+        {
+            return 80;
+        }
 
         return $width;
     }

--- a/src/TableFormatter.php
+++ b/src/TableFormatter.php
@@ -29,7 +29,7 @@ class TableFormatter
     public function __construct(Colors $colors = null)
     {
         // try to get terminal width
-        $width = $this->getTerminalWidth();
+        $width = trim( $this->getTerminalWidth() );
         if ($width) {
             $this->max = $width - 1;
         }
@@ -89,7 +89,7 @@ class TableFormatter
      *
      * @return int terminal width, 0 if unknown
      */
-    protected function getTerminalWidth()
+    protected function getTerminalWidth() : int
     {
         // from environment
         if (isset($_SERVER['COLUMNS'])) return (int)$_SERVER['COLUMNS'];
@@ -101,7 +101,7 @@ class TableFormatter
             return 80;
         }
 
-        return $width;
+        return (int)$width;
     }
 
     /**
@@ -115,7 +115,7 @@ class TableFormatter
      * @return int[]
      * @throws Exception
      */
-    protected function calculateColLengths($columns)
+    protected function calculateColLengths(array $columns) : array
     {
         $idx = 0;
         $border = $this->strlen($this->border);

--- a/tests/ArgumentTest.php
+++ b/tests/ArgumentTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace splitbrain\phpcli\tests;
+
+class argumentOptions extends \splitbrain\phpcli\Options
+{
+    public $args;
+}
+
+class ArgumentTest extends \PHPUnit\Framework\TestCase
+{
+    private function getOptions() : commandOptions
+    {
+        $options = new commandOptions();
+
+        $options->registerCommand('status', 'display status info');
+        $options->registerCommand('execute', 'execute an action');
+
+        // test an option only for status command
+        $options->registerOption('server', 'server property', 's', 'server', 'status');
+
+        // register an argument for both commands
+        $options->registerArgument('flag', 'display a flag', true, ['status','execute']);
+
+        // register an argument for status command
+        $options->registerArgument('flavor', 'latte flavor', true, 'status');
+
+        // register an argument for execute command
+        $options->registerArgument('size', 'size of latte', false, 'execute');
+
+        return $options;
+    }
+
+
+    public function test_args()
+    {
+        $options = $this->getOptions();
+
+        // command, flag, flavor, size
+        $options->args = array('status', '--server=123', '1', 'pumpkin-spice', 'grande' );
+        $options->parseOptions();
+
+        $this->assertEquals('status', $options->getCmd());
+        $this->assertEquals('123', $options->getOpt('server' ) );
+        $this->assertEquals('1', $options->getArgs()[0]);
+        $this->assertEquals('pumpkin-spice', $options->getArgs()[1]);
+        $this->assertEquals('grande', $options->getArgs()[2]);
+    }
+
+
+    public function test_args_exception()
+    {
+        $this->expectException( 'splitbrain\phpcli\Exception' );
+        $options = $this->getOptions();
+
+        // command, flag, flavor, size
+        $options->args = array('status', '--notset=123', '1', 'pumpkin-spice', 'grande' );
+        $options->parseOptions();
+    }
+
+
+    public function test_args_command_exception()
+    {
+        // in my opinion, this test should fail because we pass arguments that aren't defined
+        $options = $this->getOptions();
+
+        // command, flag, flavor, size
+        $options->args = array('execute', '1', 'pumpkin-spice', 'grande', 'adsf' );
+        $options->parseOptions();
+        $this->assertEquals('1', $options->getArgs()[0]);
+    }
+}

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace splitbrain\phpcli\tests;
+
+class commandOptions extends \splitbrain\phpcli\Options
+{
+    public $args;
+}
+
+class CommandsTest extends \PHPUnit\Framework\TestCase
+{
+    private function getOptions() : commandOptions
+    {
+        $options = new commandOptions();
+
+        $options->registerCommand('status', 'display status info');
+        $options->registerCommand('execute', 'execute an action');
+        $options->registerOption('long', 'display long lines', 'l', false, ['status','execute']);
+
+        // test an option only for status command
+        $options->registerOption('server', 'server property', 's', 'server', 'status');
+
+        // test an option only for execute command
+        $options->registerOption('username', 'username property', 'u', 'username', 'execute');
+
+        return $options;
+    }
+
+
+    public function test_command()
+    {
+        $options = $this->getOptions();
+
+        $options->args = array('status', '--long', 'foo');
+        $options->parseOptions();
+
+        $this->assertEquals('status', $options->getCmd());
+        $this->assertTrue($options->getOpt('long'));
+        $this->assertEquals(array('foo'), $options->args);
+    }
+
+
+    public function test_command_again()
+    {
+        $options = $this->getOptions();
+
+        $options->args = array('execute', '--long', 'foo');
+        $options->parseOptions();
+
+        $this->assertEquals('execute', $options->getCmd());
+        $this->assertTrue($options->getOpt('long'));
+        $this->assertEquals(array('foo'), $options->args);
+    }
+
+
+    public function test_command_exception()
+    {
+        $this->expectException( 'splitbrain\phpcli\Exception' );
+        $options = $this->getOptions();
+
+        // should throw exception for an unregistered command
+        $options->args = array('foo', '--long', 'foo', '--username=123');
+        $options->parseOptions();
+    }
+
+
+    public function test_argument_exception()
+    {
+        $this->expectException( 'splitbrain\phpcli\Exception' );
+        $options = $this->getOptions();
+
+        // should throw exception
+        $options->args = array('status', '-u','123' );
+        $options->parseOptions();
+    }
+
+
+}

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -8,7 +8,7 @@ class Options extends \splitbrain\phpcli\Options
     public $args;
 }
 
-class OptionsTest extends \PHPUnit_Framework_TestCase
+class OptionsTest extends \PHPUnit\Framework\TestCase
 {
 
     function test_simpleshort()

--- a/tests/TableFormatterTest.php
+++ b/tests/TableFormatterTest.php
@@ -23,7 +23,7 @@ class TableFormatter extends \splitbrain\phpcli\TableFormatter
 
 }
 
-class TableFormatterTest extends \PHPUnit_Framework_TestCase
+class TableFormatterTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/TableFormatterTest.php
+++ b/tests/TableFormatterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace splitbrain\phpcli\tests;
 
@@ -6,7 +6,7 @@ use splitbrain\phpcli\Colors;
 
 class TableFormatter extends \splitbrain\phpcli\TableFormatter
 {
-    public function calculateColLengths($columns)
+    public function calculateColLengths(array $columns) : array
     {
         return parent::calculateColLengths($columns);
     }


### PR DESCRIPTION
I mainly wanted the ability to pass an array of commands to register option like this:

```php
$options->registerOption(
           'name',
            'The entry name',
           'n',
            'name'
            ['create', 'delete']
        );
```

in order to make sure I wasn't introducing bugs I added tests too.
I wanted to be able to use expectException so I bumped phpunit to version 6

questions/concerns?  open to discussion. 

thanks.