### PR TITLE
Make argument and option order not matter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,8 @@
     "psr-4": {
       "splitbrain\\phpcli\\": "src"
     }
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit"
   }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -65,14 +65,16 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $options = new Options();
 
         $options->registerOption('plugins', 'run on plugins only', 'p');
+        $options->registerOption('dir', 'directory path', 'd', true);
         $options->registerCommand('status', 'display status info');
         $options->registerOption('long', 'display long lines', 'l', false, 'status');
 
-        $options->args = array('-p', 'status', '--long', 'foo');
+        $options->args = array('-p', 'status', '--dir', './file', 'foo', '--long');
         $options->parseOptions();
 
         $this->assertEquals('status', $options->getCmd());
         $this->assertTrue($options->getOpt('plugins'));
+        $this->assertEquals('./file', $options->getOpt('dir'));
         $this->assertTrue($options->getOpt('long'));
         $this->assertEquals(array('foo'), $options->args);
     }


### PR DESCRIPTION
This takes care of #25. 

You can now do things like this:
```
mycommand install --no-colors
```

and even pass options after arguments, like this:

```
mycommand install package --save
```

I've also updated the options test to reflect that.