### PR TITLE
Update available colors, remove newline rtrim from ptln, and add new print function

### DIFF
--- a/src/CLI.php
+++ b/src/CLI.php
@@ -25,11 +25,11 @@ abstract class CLI
         'info' => array('ℹ ', Colors::C_CYAN, STDOUT),
         'notice' => array('☛ ', Colors::C_CYAN, STDOUT),
         'success' => array('✓ ', Colors::C_GREEN, STDOUT),
-        'warning' => array('⚠ ', Colors::C_BROWN, STDERR),
+        'warning' => array('⚠ ', Colors::C_YELLOW, STDERR),
         'error' => array('✗ ', Colors::C_RED, STDERR),
-        'critical' => array('☠ ', Colors::C_LIGHTRED, STDERR),
-        'alert' => array('✖ ', Colors::C_LIGHTRED, STDERR),
-        'emergency' => array('✘ ', Colors::C_LIGHTRED, STDERR),
+        'critical' => array('☠ ', Colors::C_LIGHT_RED, STDERR),
+        'alert' => array('✖ ', Colors::C_LIGHT_RED, STDERR),
+        'emergency' => array('✘ ', Colors::C_LIGHT_RED, STDERR),
     );
 
     protected $logdefault = 'info';

--- a/src/Colors.php
+++ b/src/Colors.php
@@ -14,42 +14,90 @@ class Colors
 {
     // these constants make IDE autocompletion easier, but color names can also be passed as strings
     const C_RESET = 'reset';
+
     const C_BLACK = 'black';
-    const C_DARKGRAY = 'darkgray';
-    const C_BLUE = 'blue';
-    const C_LIGHTBLUE = 'lightblue';
-    const C_GREEN = 'green';
-    const C_LIGHTGREEN = 'lightgreen';
-    const C_CYAN = 'cyan';
-    const C_LIGHTCYAN = 'lightcyan';
     const C_RED = 'red';
-    const C_LIGHTRED = 'lightred';
-    const C_PURPLE = 'purple';
-    const C_LIGHTPURPLE = 'lightpurple';
-    const C_BROWN = 'brown';
+    const C_GREEN = 'green';
     const C_YELLOW = 'yellow';
-    const C_LIGHTGRAY = 'lightgray';
+    const C_BLUE = 'blue';
+    const C_MAGENTA = 'magenta';
+    const C_CYAN = 'cyan';
     const C_WHITE = 'white';
+
+    const C_LIGHT_BLACK = 'lightblack';
+    const C_LIGHT_RED = 'lightred';
+    const C_LIGHT_GREEN = 'lightgreen';
+    const C_LIGHT_YELLOW = 'lightyellow';
+    const C_LIGHT_BLUE = 'lightblue';
+    const C_LIGHT_MAGENTA = 'lightmagenta';
+    const C_LIGHT_CYAN = 'lightcyan';
+    const C_LIGHT_WHITE = 'lightwhite';
+
+    const C_BLACK_BACKGROUND = 'blackbackground';
+    const C_RED_BACKGROUND = 'redbackground';
+    const C_GREEN_BACKGROUND = 'greenbackground';
+    const C_YELLOW_BACKGROUND = 'yellowbackground';
+    const C_BLUE_BACKGROUND = 'bluebackground';
+    const C_MAGENTA_BACKGROUND = 'magentabackground';
+    const C_CYAN_BACKGROUND = 'cyanbackground';
+    const C_WHITE_BACKGROUND = 'whitebackground';
+
+    const C_LIGHT_BLACK_BACKGROUND = 'lightblackbackground';
+    const C_LIGHT_RED_BACKGROUND = 'lightredbackground';
+    const C_LIGHT_GREEN_BACKGROUND = 'lightgreenbackground';
+    const C_LIGHT_YELLOW_BACKGROUND = 'lightyellowbackground';
+    const C_LIGHT_BLUE_BACKGROUND = 'lightbluebackground';
+    const C_LIGHT_MAGENTA_BACKGROUND = 'lightmagentabackground';
+    const C_LIGHT_CYAN_BACKGROUND = 'lightcyanbackground';
+    const C_LIGHT_WHITE_BACKGROUND = 'lightwhitebackground';
+
+    const C_BOLD = 'bold';
+    const C_UNDERLINE = 'underline';
+    const C_REVERSED = 'reversed';
 
     /** @var array known color names */
     protected $colors = array(
         self::C_RESET => "\33[0m",
-        self::C_BLACK => "\33[0;30m",
-        self::C_DARKGRAY => "\33[1;30m",
-        self::C_BLUE => "\33[0;34m",
-        self::C_LIGHTBLUE => "\33[1;34m",
-        self::C_GREEN => "\33[0;32m",
-        self::C_LIGHTGREEN => "\33[1;32m",
-        self::C_CYAN => "\33[0;36m",
-        self::C_LIGHTCYAN => "\33[1;36m",
-        self::C_RED => "\33[0;31m",
-        self::C_LIGHTRED => "\33[1;31m",
-        self::C_PURPLE => "\33[0;35m",
-        self::C_LIGHTPURPLE => "\33[1;35m",
-        self::C_BROWN => "\33[0;33m",
-        self::C_YELLOW => "\33[1;33m",
-        self::C_LIGHTGRAY => "\33[0;37m",
-        self::C_WHITE => "\33[1;37m",
+
+        self::C_BLACK => "\33[30m",
+        self::C_RED => "\33[31m",
+        self::C_GREEN => "\33[32m",
+        self::C_YELLOW => "\33[33m",
+        self::C_BLUE => "\33[34m",
+        self::C_MAGENTA => "\33[35m",
+        self::C_CYAN => "\33[36m",
+        self::C_WHITE => "\33[37m",
+
+        self::C_LIGHT_BLACK => "\33[1;30m",
+        self::C_LIGHT_RED => "\33[1;31m",
+        self::C_LIGHT_GREEN => "\33[1;32m",
+        self::C_LIGHT_YELLOW => "\33[1;33m",
+        self::C_LIGHT_BLUE => "\33[1;34m",
+        self::C_LIGHT_MAGENTA => "\33[1;35m",
+        self::C_LIGHT_CYAN => "\33[1;36m",
+        self::C_LIGHT_WHITE => "\33[1;37m",
+
+        self::C_BLACK_BACKGROUND => "\33[40m",
+        self::C_RED_BACKGROUND => "\33[41m",
+        self::C_GREEN_BACKGROUND => "\33[42m",
+        self::C_YELLOW_BACKGROUND => "\33[43m",
+        self::C_BLUE_BACKGROUND => "\33[44m",
+        self::C_MAGENTA_BACKGROUND => "\33[45m",
+        self::C_CYAN_BACKGROUND => "\33[46m",
+        self::C_WHITE_BACKGROUND => "\33[47m",
+
+        self::C_LIGHT_BLACK_BACKGROUND => "\33[1;40m",
+        self::C_LIGHT_RED_BACKGROUND => "\33[1;41m",
+        self::C_LIGHT_GREEN_BACKGROUND => "\33[1;42m",
+        self::C_LIGHT_YELLOW_BACKGROUND => "\33[1;43m",
+        self::C_LIGHT_BLUE_BACKGROUND => "\33[1;44m",
+        self::C_LIGHT_MAGENTA_BACKGROUND => "\33[1;45m",
+        self::C_LIGHT_CYAN_BACKGROUND => "\33[1;46m",
+        self::C_LIGHT_WHITE_BACKGROUND => "\33[1;47m",
+
+        self::C_BOLD => "\33[1m",
+        self::C_UNDERLINE => "\33[4m",
+        self::C_REVERSED => "\33[7m",
     );
 
     /** @var bool should colors be used? */
@@ -108,7 +156,7 @@ class Colors
     public function ptln($line, $color, $channel = STDOUT)
     {
         $this->set($color);
-        fwrite($channel, rtrim($line) . "\n");
+        fwrite($channel, $line . "\n");
         $this->reset();
     }
 
@@ -166,5 +214,46 @@ class Colors
     public function reset($channel = STDOUT)
     {
         $this->set('reset', $channel);
+    }
+
+    /**
+     * Prints text using color codes
+     *
+     * @param string $text string to print
+     * @param resource $channel file descriptor to write to
+     *
+     * @throws Exception
+     */
+    public function print($text, $channel = STDOUT)
+    {
+        $active_colors = array();
+
+        $text = preg_replace_callback('/\<(.[^\>]*?)\>/', function ($matches) use (&$active_colors) {
+            $new_color = $matches[1];
+            $colors = array();
+
+            if (!isset($this->colors[$new_color]) && !isset($this->colors[substr($new_color, 1)])) {
+                return "<$new_color>";
+            }
+
+            if (substr($new_color, 0, 1) === '/') {
+                array_pop($active_colors);
+                $colors[] = 'reset';
+            } else {
+                $active_colors[] = $new_color;
+            }
+
+            $colors = array_merge($colors, $active_colors);
+
+            return implode('', array_map(function ($color) {
+                return $this->getColorCode($color);
+            }, $colors));
+        }, $text);
+
+        fwrite($channel, $text . "\n");
+
+        if (end($active_colors) !== 'reset') {
+            $this->reset($channel);
+        }
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -62,7 +62,7 @@ class Options
 
         $this->options = array();
     }
-    
+
     /**
      * Gets the bin value
      */
@@ -374,13 +374,13 @@ class Options
 
             // usage or command syntax line
             if (!$command) {
-                $text .= $this->colors->wrap('USAGE:', Colors::C_BROWN);
+                $text .= $this->colors->wrap('USAGE:', Colors::C_YELLOW);
                 $text .= "\n";
                 $text .= '   ' . $this->bin;
                 $mv = 2;
             } else {
                 $text .= $this->newline;
-                $text .= $this->colors->wrap('   ' . $command, Colors::C_PURPLE);
+                $text .= $this->colors->wrap('   ' . $command, Colors::C_MAGENTA);
                 $mv = 4;
             }
 
@@ -389,7 +389,7 @@ class Options
             }
 
             if (!$command && $hascommands) {
-                $text .= ' ' . $this->colors->wrap('<COMMAND> ...', Colors::C_PURPLE);
+                $text .= ' ' . $this->colors->wrap('<COMMAND> ...', Colors::C_MAGENTA);
             }
 
             foreach ($this->setup[$command]['args'] as $arg) {
@@ -415,7 +415,7 @@ class Options
             if ($hasopts) {
                 if (!$command) {
                     $text .= "\n";
-                    $text .= $this->colors->wrap('OPTIONS:', Colors::C_BROWN);
+                    $text .= $this->colors->wrap('OPTIONS:', Colors::C_YELLOW);
                 }
                 $text .= "\n";
                 foreach ($this->setup[$command]['opts'] as $long => $opt) {
@@ -446,7 +446,7 @@ class Options
             if ($hasargs) {
                 if (!$command) {
                     $text .= "\n";
-                    $text .= $this->colors->wrap('ARGUMENTS:', Colors::C_BROWN);
+                    $text .= $this->colors->wrap('ARGUMENTS:', Colors::C_YELLOW);
                 }
                 $text .= $this->newline;
                 foreach ($this->setup[$command]['args'] as $arg) {
@@ -463,7 +463,7 @@ class Options
             // head line and intro for following command documentation
             if (!$command && $hascommands) {
                 $text .= "\n";
-                $text .= $this->colors->wrap('COMMANDS:', Colors::C_BROWN);
+                $text .= $this->colors->wrap('COMMANDS:', Colors::C_YELLOW);
                 $text .= "\n";
                 $text .= $tf->format(
                     array($mv, '*'),
@@ -501,4 +501,3 @@ class Options
         return $argv;
     }
 }
-


### PR DESCRIPTION
So let me know your thoughts on this:

This PR implements a few changes:

1.) **Update available colors**
So as the project is right now, some of the colors are kind of one wouldn't normally expect with terminal colors (like if you normally use https://www.npmjs.com/package/colors in Node), for example, Yellow=Brown, Light Yellow = Yellow, Magenta = Purple, Light Magenta = Light Purple. I updated the colors to match what is defined here: https://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html

I also added background colors as well as bold, underline, and reversed styles. I understand this is a breaking change but I think it would be worth it.

2.) **Remove newline rtrim from the ptln function**
Right now the function trims any new line characters from the end of the text making it not possible to add an empty line to text unless you call the function again with an empty string.

3.) **Add new print function**
I wasn't sure what to call this function, originally I named it `format` however that doesn't imply that the text will be printed on the screen and I didn't want to have to wrap this function in ptln (which wouldn't even really be possible because that function requires you to define a color). But basically this function allows you to use color codes to combine difference colors easily. For example:

```php
$this->colors->print("<black><redbackground>U</redbackground><whitebackground>S</whitebackground><bluebackground>A</bluebackground></black>");
```

Instead of throwing an error if someone puts an invalid color code, it just treats it as normal text.

Let me know what you think!