### PR TITLE
fixes colors on streams other than stdout

### DIFF
--- a/src/Colors.php
+++ b/src/Colors.php
@@ -107,9 +107,9 @@ class Colors
      */
     public function ptln($line, $color, $channel = STDOUT)
     {
-        $this->set($color);
+        $this->set($color, $channel);
         fwrite($channel, rtrim($line) . "\n");
-        $this->reset();
+        $this->reset($channel);
     }
 
     /**


### PR DESCRIPTION
Currently color codes are always written to STDOUT, not the stream associated with a particular log level. This fixes it to write codes to the same channel as the message text.