### PR TITLE
Fixes issue #33: setLogLevel works in reversed order

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -229,10 +229,10 @@ abstract class Base
     public function setLogLevel($level)
     {
         if (!isset($this->loglevel[$level])) $this->fatal('Unknown log level');
-        $enable = true;
+        $enable = false;
         foreach (array_keys($this->loglevel) as $l) {
             $this->loglevel[$l]['enabled'] = $enable;
-            if ($l == $level) $enable = false;
+            if ($l == $level) break;
         }
     }
 


### PR DESCRIPTION
This request fixes issue #33.

Original issue is that loglevels work in reversed order: if you specify, for example, warning, then all levels from debug to warning is shown, however, top levels (error, emergency, etc) are not.

After the fix, if you specify "warning", then warning, error and emergency levels are shown. 