### PR TITLE
Update constructor to accept nullable Colors parameter

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -40,7 +40,7 @@ class Options
      * @param Colors $colors optional configured color object
      * @throws Exception when arguments can't be read
      */
-    public function __construct(Colors $colors = null)
+    public function __construct(?Colors $colors = null)
     {
         if (!is_null($colors)) {
             $this->colors = $colors;


### PR DESCRIPTION
This will resolve issues in PHP 8.4 like the following
```
PHP Deprecated:  splitbrain\phpcli\Options::__construct(): Implicitly marking parameter $colors as nullable is deprecated, the explicit nullable type must be used instead in phpdraft/vendor/splitbrain/php-cli/src/Options.php on line 43
```